### PR TITLE
Feature/valve handling

### DIFF
--- a/Classes/Serial/ARCaDIUS_Serial.h
+++ b/Classes/Serial/ARCaDIUS_Serial.h
@@ -65,7 +65,9 @@ class ASerial {
     int pumpDir;
 
     int valve;
-    int valveState;
+    int valveToOpen;
+    //IF NUMBER OF VALVES CHANGE, CHANGE ARRAY SIZE
+    int valveStates[5];
 
     int mixer;
     float mixerSpeed;
@@ -79,7 +81,8 @@ class ASerial {
 
     void Pump();
     void Mixer();
-    void Valve();
+    void OpenOneValve();
+    void OpenMultipleValves();
     void Shutter();
     void Extract();
 
@@ -147,7 +150,6 @@ class ASerial {
     bool getPumpDir();
 
     int getValve();
-    bool getValveState();
 
     int getMixer();
     int getMixerSpeed();

--- a/Modules/1004 IN/ARCaDIUS_IN4/ARCaDIUS_IN4.ino
+++ b/Modules/1004 IN/ARCaDIUS_IN4/ARCaDIUS_IN4.ino
@@ -34,17 +34,7 @@ void loop() {
     //[sID1000 rID1001 PK1 R]   
     switch (Device.GetCommand()) {      
       case PUMP: //[sID1000 rID1001 PK2 P1 m3.0]
-        /*
-        Serial.println("The pump number is: " + (String)Device.getPump());
-        Serial.println("The pump volume in mls is: " + (String)Device.getPumpMls());
-        Serial.println("The pump direction is: " + (String)Device.getPumpDir());*/
-        switch (Device.getPump()) {
-          case 1:
-            P1.set_vol(Device.getPumpMls(),Device.getPumpDir());
-            break;
-          default:
-            break;
-        }
+        P1.set_vol(Device.getPumpMls(),Device.getPumpDir());
         break;
       case MIXER: //[sID1000 rID1001 PK3 M1 S1 D1]
         break;

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
@@ -61,30 +61,7 @@ void loop() {
       case MIXER: // Enter code for mixer here
         break;
       case VALVE:
-        Serial.println("Packet Size: " + (String)Device.GetPKSize());
-        switch (Device.getValve()) {//test [sID1000 rID1004 PK2 V1 S0]
-          case 0:
-            valveController.closeAllValves();
-          case 1:
-            valveController.openValve1();
-            break;
-          case 2:
-            valveController.openValve2();
-            break;
-          case 3:
-            valveController.openValve3();
-            break;
-          case 4:
-            valveController.openValve4();
-            break;
-          case 5:
-            valveController.openValve5();
-            break;
-          default:
-            valveController.setPositionOfValves(Device.getValveStates());
-            break;
-        }
-        
+        valveController.setPositionOfValves(Device.getValve());
         break;
       case SHUTTER: // Enter code for shutter here
         Serial.println("The shutter number is: " + (String)Device.getShutter());

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
@@ -61,6 +61,7 @@ void loop() {
       case MIXER: // Enter code for mixer here
         break;
       case VALVE:
+        Serial.println("Packet Size: " + (String)Device.GetPKSize());
         switch (Device.getValve()) {//test [sID1000 rID1004 PK2 V1 S0]
           case 0:
             valveController.closeAllValves();

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
@@ -96,6 +96,7 @@ void loop() {
             Serial.println("valve angle:  " + (String)Valve5.get_pos_analog());
             break;
           default:
+            valveController.setPositionOfValves(Device.getValveStates());
             break;
         }
         

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
@@ -25,6 +25,7 @@ Valve Valve2(5, 65, 127);
 Valve Valve3(6, 65, 128);
 Valve Valve4(9, 65, 127);
 Valve Valve5(10, 66, 130);
+ValveHandler valveController(Valve1, Valve2, Valve3, Valve4, Valve5);
 Pump P1(11);
 
 void setup() {
@@ -62,7 +63,7 @@ void loop() {
       case VALVE:
         switch (Device.getValve()) {//test [sID1000 rID1004 PK2 V1 S0]
           case 1:
-            Valve1.set_pos(Device.getValveState());
+            valveController.openValve1();
             Serial.println("valve number: " + (String)Device.getValve());
             Serial.println("valve state:  " + (String)Valve1.get_pos_digital());
             Serial.println("valve angle:  " + (String)Valve1.get_pos_analog());

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
@@ -69,25 +69,25 @@ void loop() {
             Serial.println("valve angle:  " + (String)Valve1.get_pos_analog());
             break;
           case 2:
-            Valve2.set_pos(Device.getValveState());
+            valveController.openValve2();
             Serial.println("valve number: " + (String)Device.getValve());
             Serial.println("valve state:  " + (String)Valve2.get_pos_digital());
             Serial.println("valve angle:  " + (String)Valve2.get_pos_analog());
             break;
           case 3:
-            Valve3.set_pos(Device.getValveState());
+            valveController.openValve3();
             Serial.println("valve number: " + (String)Device.getValve());
             Serial.println("valve state:  " + (String)Valve3.get_pos_digital());
             Serial.println("valve angle:  " + (String)Valve3.get_pos_analog());
             break;
           case 4:
-            Valve4.set_pos(Device.getValveState());
+            valveController.openValve4();
             Serial.println("valve number: " + (String)Device.getValve());
             Serial.println("valve state:  " + (String)Valve4.get_pos_digital());
             Serial.println("valve angle:  " + (String)Valve4.get_pos_analog());
             break;
           case 5:
-            Valve5.set_pos(Device.getValveState());
+            valveController.openValve5();
             Serial.println("valve number: " + (String)Device.getValve());
             Serial.println("valve state:  " + (String)Valve5.get_pos_digital());
             Serial.println("valve angle:  " + (String)Valve5.get_pos_analog());

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
@@ -67,33 +67,18 @@ void loop() {
             valveController.closeAllValves();
           case 1:
             valveController.openValve1();
-            Serial.println("valve number: " + (String)Device.getValve());
-            Serial.println("valve state:  " + (String)Valve1.get_pos_digital());
-            Serial.println("valve angle:  " + (String)Valve1.get_pos_analog());
             break;
           case 2:
             valveController.openValve2();
-            Serial.println("valve number: " + (String)Device.getValve());
-            Serial.println("valve state:  " + (String)Valve2.get_pos_digital());
-            Serial.println("valve angle:  " + (String)Valve2.get_pos_analog());
             break;
           case 3:
             valveController.openValve3();
-            Serial.println("valve number: " + (String)Device.getValve());
-            Serial.println("valve state:  " + (String)Valve3.get_pos_digital());
-            Serial.println("valve angle:  " + (String)Valve3.get_pos_analog());
             break;
           case 4:
             valveController.openValve4();
-            Serial.println("valve number: " + (String)Device.getValve());
-            Serial.println("valve state:  " + (String)Valve4.get_pos_digital());
-            Serial.println("valve angle:  " + (String)Valve4.get_pos_analog());
             break;
           case 5:
             valveController.openValve5();
-            Serial.println("valve number: " + (String)Device.getValve());
-            Serial.println("valve state:  " + (String)Valve5.get_pos_digital());
-            Serial.println("valve angle:  " + (String)Valve5.get_pos_analog());
             break;
           default:
             valveController.setPositionOfValves(Device.getValveStates());

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
@@ -62,6 +62,8 @@ void loop() {
         break;
       case VALVE:
         switch (Device.getValve()) {//test [sID1000 rID1004 PK2 V1 S0]
+          case 0:
+            valveController.closeAllValves();
           case 1:
             valveController.openValve1();
             Serial.println("valve number: " + (String)Device.getValve());

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_OUT.ino
@@ -50,13 +50,7 @@ void loop() {
     Device.updateSensors(TEMP, 1, sensors.getTempCByIndex(0));
     switch (Device.GetCommand()) {
       case PUMP: 
-        switch (Device.getPump()) {//[sID1000 rID1004 PK3 P1 m5.00]
-          case 1:
-            P1.set_vol(Device.getPumpMls(),Device.getPumpDir());
-            break;
-          default:
-            break;
-        }
+        P1.set_vol(Device.getPumpMls(),Device.getPumpDir());
         break;
       case MIXER: // Enter code for mixer here
         break;

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.cpp
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.cpp
@@ -377,7 +377,7 @@ bool ASerial::getPumpDir() {
 int ASerial::getValve() {
   return (int)valveToOpen;
 }
-bool ASerial::getValveStates() {
+int ASerial::getValveStates() {
   return valveStates;
 }
 int ASerial::getMixer() {

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.cpp
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.cpp
@@ -226,12 +226,9 @@ String readStringuntil(String s, char c) {
 
 void ASerial::Pump() {
   String rubbish;
-  pump = Command[1] - '0';
-  //Serial.println(pump);
   rubbish = readStringuntil(Command, 'm');
   Command.remove(0, rubbish.length());
   pumpValue = readStringuntil(Command, ' ').toFloat();
-  //Serial.println(pumpValue);
   rubbish = readStringuntil(Command, 'D');
   Command.remove(0, rubbish.length());
   if (pumpValue > 0) {
@@ -240,24 +237,26 @@ void ASerial::Pump() {
   else {
     pumpDir = 0;
   }
-  //pumpDir = Command[0] - '0';
-  //Serial.println(pumpDir);
 }
 
 void ASerial::OpenOneValve()
 {
+  String rubbish;
+  rubbish = readStringuntil(Command, 'S');
+  //Remove command bit
+  Command.remove(0, rubbish.length());
   //Get valve to open
-  valveToOpen = Command[1] - '0';
+  valveToOpen = Command[0] - '0';
 
   //Set valve positions based on valve number
   for(int i = 0; i < NumValve; i++)
   {
     //If i == valveToOpen then open, i < valveToOpen then close, i > valveToOpen then middle
-    if(i == valveToOpen)
+    if(i + 1 == valveToOpen)
     {
       valveStates[i] = 0;
     }
-    else if (i < valveToOpen)
+    else if (i + 1 < valveToOpen)
     {
       valveStates[i] = 1;
     }
@@ -270,8 +269,10 @@ void ASerial::OpenOneValve()
 
 void ASerial::OpenMultipleValves()
 {
+  String rubbish;
+  rubbish = readStringuntil(Command, 'S');
   //Remove command bit
-  Command.remove(0, 1);
+  Command.remove(0, rubbish.length());
   for(int i = 0; i < NumValve; i++)
   {
     int valveState = Command[0] - '0';

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.cpp
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.cpp
@@ -242,12 +242,23 @@ void ASerial::Pump() {
 
 void ASerial::Valve() {
   String rubbish;
-  valve = Command[1] - '0';
-  //Serial.println(valve);
-  rubbish = readStringuntil(Command, 'S');
-  Command.remove(0, rubbish.length());
-  valveState = Command[0] - '0';
-  //Serial.println(valveState);
+  valveToOpen = Command[1] - '0';
+  if(GetPKSize() == 2)
+  {
+    rubbish = readStringuntil(Command, 'S');
+    Command.remove(0, rubbish.length());
+    for(int i = 0; i < 5; i++)
+    {
+      int valveState = Command[0] - '0';
+      if(valveState >= 3 || valveState < 0)
+      {
+        Error(4);
+      }
+      valveStates[i] = Command[0] - '0';
+      Command.remove(0, 1);
+      Serial.println("Valve " + (String)i + " position is " + (String)valveStates[i]);
+    }
+  }
 }
 
 void ASerial::Mixer() {
@@ -305,6 +316,7 @@ void ASerial::updateSensors(SENSOR s, int Num, float Val) {
       LDSVal[Num-1] = Val;
       break;
     case TEMP:
+      Serial.println(Val);
       TempVal[Num-1] = Val;
       break;
     case BUBBLE:
@@ -363,10 +375,10 @@ bool ASerial::getPumpDir() {
   return pumpDir;
 }
 int ASerial::getValve() {
-  return (int)valve;
+  return (int)valveToOpen;
 }
-bool ASerial::getValveState() {
-  return valveState;
+bool ASerial::getValveStates() {
+  return valveStates;
 }
 int ASerial::getMixer() {
   return mixer;

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.cpp
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.cpp
@@ -186,6 +186,7 @@ void ASerial::analyse() {
       Shutter();
       break;
     case 'R':
+      op = READ;
       readSensors();
       break;
     case 'D':

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.h
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.h
@@ -147,7 +147,7 @@ class ASerial {
     bool getPumpDir();
 
     int getValve();
-    bool getValveStates();
+    int getValveStates();
 
     int getMixer();
     int getMixerSpeed();

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.h
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.h
@@ -64,8 +64,8 @@ class ASerial {
     float pumpValue;
     int pumpDir;
 
-    int valve;
-    int valveState;
+    int valveToOpen;
+    int valveStates[5];
 
     int mixer;
     float mixerSpeed;
@@ -147,7 +147,7 @@ class ASerial {
     bool getPumpDir();
 
     int getValve();
-    bool getValveState();
+    bool getValveStates();
 
     int getMixer();
     int getMixerSpeed();

--- a/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.h
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/ARCaDIUS_Serial.h
@@ -64,7 +64,9 @@ class ASerial {
     float pumpValue;
     int pumpDir;
 
+    int valve;
     int valveToOpen;
+    //IF NUMBER OF VALVES CHANGE, CHANGE ARRAY SIZE
     int valveStates[5];
 
     int mixer;
@@ -79,7 +81,8 @@ class ASerial {
 
     void Pump();
     void Mixer();
-    void Valve();
+    void OpenOneValve();
+    void OpenMultipleValves();
     void Shutter();
     void Extract();
 
@@ -147,7 +150,6 @@ class ASerial {
     bool getPumpDir();
 
     int getValve();
-    int getValveStates();
 
     int getMixer();
     int getMixerSpeed();

--- a/Modules/1005 OUT/ARCaDIUS_OUT/Valve.cpp
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/Valve.cpp
@@ -68,66 +68,12 @@ int Valve::get_lim(int pos) {
 } // End function
 
 /*
-  ValveHandler::openvalveX()
-  Sets valve X to be open. If valve number > X, sets valve to the middle position.
-  If valve number < X, sets valve to the closed position.
+  ValveHandler::setPositionOfValves(int valveStates[5])
+
+  valveStates[5] : Array containing position of each individual valve. Array length of 5 because of the 5 valves in the output module.
+
+  Sets position of valves according to input array.
 */
-
-void ValveHandler::openValve1()
-{
-  V1.set_pos(0);
-  V2.set_pos(2);
-  V3.set_pos(2);
-  V4.set_pos(2);
-  V5.set_pos(2);
-}
-
-void ValveHandler::openValve2()
-{
-  V1.set_pos(1);
-  V2.set_pos(0);
-  V3.set_pos(2);
-  V4.set_pos(2);
-  V5.set_pos(2);
-}
-
-void ValveHandler::openValve3()
-{
-  V1.set_pos(1);
-  V2.set_pos(1);
-  V3.set_pos(0);
-  V4.set_pos(2);
-  V5.set_pos(2);
-}
-
-void ValveHandler::openValve4()
-{
-  V1.set_pos(1);
-  V2.set_pos(1);
-  V3.set_pos(1);
-  V4.set_pos(0);
-  V5.set_pos(2);
-}
-
-void ValveHandler::openValve5()
-{
-  V1.set_pos(1);
-  V2.set_pos(1);
-  V3.set_pos(1);
-  V4.set_pos(1);
-  V5.set_pos(0);
-}
-
-//Closes all valves
-void ValveHandler::closeAllValves()
-{
-  V1.set_pos(1);
-  V2.set_pos(1);
-  V3.set_pos(1);
-  V4.set_pos(1);
-  V5.set_pos(1);
-}
-
 void ValveHandler::setPositionOfValves(int valveStates[5])
 {
   V1.set_pos(valveStates[0]);

--- a/Modules/1005 OUT/ARCaDIUS_OUT/Valve.cpp
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/Valve.cpp
@@ -28,8 +28,6 @@ void Valve::set_pos(int pos) {
     default:
       break;
   }
-  Serial.println(pinSer);
-  Serial.println(get_pos_analog());
 }
 
 

--- a/Modules/1005 OUT/ARCaDIUS_OUT/Valve.cpp
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/Valve.cpp
@@ -69,52 +69,63 @@ int Valve::get_lim(int pos) {
   }
 } // End function
 
+/*
+  ValveHandler::openvalveX()
+  Sets valve X to be open. If valve number > X, sets valve to the middle position.
+  If valve number < X, sets valve to the closed position.
+*/
+
 void ValveHandler::openValve1()
 {
-  //Open Valve 1, close other valves
   V1.set_pos(0);
-  V2.set_pos(1);
-  V3.set_pos(1);
-  V4.set_pos(1);
-  V5.set_pos(1);
+  V2.set_pos(2);
+  V3.set_pos(2);
+  V4.set_pos(2);
+  V5.set_pos(2);
 }
 
 void ValveHandler::openValve2()
 {
-  //Open Valve 2, close other valves
   V1.set_pos(1);
   V2.set_pos(0);
-  V3.set_pos(1);
-  V4.set_pos(1);
-  V5.set_pos(1);
+  V3.set_pos(2);
+  V4.set_pos(2);
+  V5.set_pos(2);
 }
 
 void ValveHandler::openValve3()
 {
-  //Open Valve 3, close other valves
   V1.set_pos(1);
   V2.set_pos(1);
   V3.set_pos(0);
-  V4.set_pos(1);
-  V5.set_pos(1);
+  V4.set_pos(2);
+  V5.set_pos(2);
 }
 
 void ValveHandler::openValve4()
 {
-  //Open Valve 4, close other valves
   V1.set_pos(1);
   V2.set_pos(1);
   V3.set_pos(1);
   V4.set_pos(0);
-  V5.set_pos(1);
+  V5.set_pos(2);
 }
 
 void ValveHandler::openValve5()
 {
-  //Open Valve 5, close other valves
   V1.set_pos(1);
   V2.set_pos(1);
   V3.set_pos(1);
   V4.set_pos(1);
   V5.set_pos(0);
+}
+
+//Closes all valves
+void ValveHandler::closeAllValves()
+{
+  V1.set_pos(1);
+  V2.set_pos(1);
+  V3.set_pos(1);
+  V4.set_pos(1);
+  V5.set_pos(1);
 }

--- a/Modules/1005 OUT/ARCaDIUS_OUT/Valve.cpp
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/Valve.cpp
@@ -129,3 +129,12 @@ void ValveHandler::closeAllValves()
   V4.set_pos(1);
   V5.set_pos(1);
 }
+
+void ValveHandler::setPositionOfValves(int valveStates[5])
+{
+  V1.set_pos(valveStates[0]);
+  V2.set_pos(valveStates[1]);
+  V3.set_pos(valveStates[2]);
+  V4.set_pos(valveStates[3]);
+  V5.set_pos(valveStates[4]);
+}

--- a/Modules/1005 OUT/ARCaDIUS_OUT/Valve.cpp
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/Valve.cpp
@@ -28,6 +28,8 @@ void Valve::set_pos(int pos) {
     default:
       break;
   }
+  Serial.println(pinSer);
+  Serial.println(get_pos_analog());
 }
 
 
@@ -66,3 +68,13 @@ int Valve::get_lim(int pos) {
     return angleMid;
   }
 } // End function
+
+void ValveHandler::openValve1()
+{
+  //Open Valve 1, close other valves
+  V1.set_pos(0);
+  V2.set_pos(1);
+  V3.set_pos(1);
+  V4.set_pos(1);
+  V5.set_pos(1);
+}

--- a/Modules/1005 OUT/ARCaDIUS_OUT/Valve.cpp
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/Valve.cpp
@@ -78,3 +78,43 @@ void ValveHandler::openValve1()
   V4.set_pos(1);
   V5.set_pos(1);
 }
+
+void ValveHandler::openValve2()
+{
+  //Open Valve 2, close other valves
+  V1.set_pos(1);
+  V2.set_pos(0);
+  V3.set_pos(1);
+  V4.set_pos(1);
+  V5.set_pos(1);
+}
+
+void ValveHandler::openValve3()
+{
+  //Open Valve 3, close other valves
+  V1.set_pos(1);
+  V2.set_pos(1);
+  V3.set_pos(0);
+  V4.set_pos(1);
+  V5.set_pos(1);
+}
+
+void ValveHandler::openValve4()
+{
+  //Open Valve 4, close other valves
+  V1.set_pos(1);
+  V2.set_pos(1);
+  V3.set_pos(1);
+  V4.set_pos(0);
+  V5.set_pos(1);
+}
+
+void ValveHandler::openValve5()
+{
+  //Open Valve 5, close other valves
+  V1.set_pos(1);
+  V2.set_pos(1);
+  V3.set_pos(1);
+  V4.set_pos(1);
+  V5.set_pos(0);
+}

--- a/Modules/1005 OUT/ARCaDIUS_OUT/Valve.h
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/Valve.h
@@ -60,6 +60,8 @@ class Valve{
     int get_lim(int pos);
 };
 
+
+//Valve handler class to handle logic of valves on firmware side. Can increase number of valves if needed, but functions will also need to change to reflect this.
 class ValveHandler{
   private:
   Valve V1;
@@ -69,14 +71,7 @@ class ValveHandler{
   Valve V5;
   public:
 // Constructor and initial settings
-    ValveHandler(Valve Valve1, Valve Valve2, Valve Valve3, Valve Valve4, Valve Valve5):V1(Valve1), V2(Valve2), V3(Valve3), V4(Valve4), V5(Valve5){}
-
-  void openValve1();
-  void openValve2();
-  void openValve3();
-  void openValve4();
-  void openValve5();
-  void closeAllValves();
+  ValveHandler(Valve Valve1, Valve Valve2, Valve Valve3, Valve Valve4, Valve Valve5):V1(Valve1), V2(Valve2), V3(Valve3), V4(Valve4), V5(Valve5){}
 
   void setPositionOfValves(int valveStates[5]);
 };

--- a/Modules/1005 OUT/ARCaDIUS_OUT/Valve.h
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/Valve.h
@@ -77,5 +77,7 @@ class ValveHandler{
   void openValve4();
   void openValve5();
   void closeAllValves();
+
+  void setPositionOfValves(int valveStates[5]);
 };
 #endif

--- a/Modules/1005 OUT/ARCaDIUS_OUT/Valve.h
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/Valve.h
@@ -76,5 +76,6 @@ class ValveHandler{
   void openValve3();
   void openValve4();
   void openValve5();
+  void closeAllValves();
 };
 #endif

--- a/Modules/1005 OUT/ARCaDIUS_OUT/Valve.h
+++ b/Modules/1005 OUT/ARCaDIUS_OUT/Valve.h
@@ -60,4 +60,21 @@ class Valve{
     int get_lim(int pos);
 };
 
+class ValveHandler{
+  private:
+  Valve V1;
+  Valve V2;
+  Valve V3;
+  Valve V4;
+  Valve V5;
+  public:
+// Constructor and initial settings
+    ValveHandler(Valve Valve1, Valve Valve2, Valve Valve3, Valve Valve4, Valve Valve5):V1(Valve1), V2(Valve2), V3(Valve3), V4(Valve4), V5(Valve5){}
+
+  void openValve1();
+  void openValve2();
+  void openValve3();
+  void openValve4();
+  void openValve5();
+};
 #endif

--- a/Modules/1006 SHUT/ARCaDIUS_SHUT/ARCaDIUS_SHUT.ino
+++ b/Modules/1006 SHUT/ARCaDIUS_SHUT/ARCaDIUS_SHUT.ino
@@ -42,7 +42,7 @@ void loop() {
           MagMix.StopMotor();
         }
         else {
-          MagMix.SetSpeed(Device.getMixerSpeed());
+          MagMix.SetSpeed(Device.getMixerSpeed(), Device.getMixerDir());
         }
         break;
 
@@ -51,7 +51,6 @@ void loop() {
         break;
 
       case SHUTTER:  
-        Serial.println("The shutter number is: " + (String)Device.getShutter());
         Serial.println("Shutter position: " + (String)Device.getShutterPos());
         //[sID1000 rID1005 PK3 I1 S1]
         switch (Device.getShutterPos()) {
@@ -62,13 +61,11 @@ void loop() {
             shutter.moveto(120, 0); //change 0 to 1 for control
             break;
           case 2:
-          Serial.println("Hi");
             shutter.moveto(240, 0); //change 0 to 1 for control
             break;
           default:
             break;
         }
-
       default: // Leave this, its just the default
         break;
     }

--- a/Modules/1006 SHUT/ARCaDIUS_SHUT/ARCaDIUS_Serial.cpp
+++ b/Modules/1006 SHUT/ARCaDIUS_SHUT/ARCaDIUS_Serial.cpp
@@ -266,7 +266,6 @@ void ASerial::Mixer() {
 
 void ASerial::Shutter() {
   String rubbish;
-  shutter = Command[1] - '0';
   //Serial.println(shutter);
   rubbish = readStringuntil(Command, 'S');
   Command.remove(0, rubbish.length());

--- a/Modules/1006 SHUT/ARCaDIUS_SHUT/MixerMotor.cpp
+++ b/Modules/1006 SHUT/ARCaDIUS_SHUT/MixerMotor.cpp
@@ -14,11 +14,17 @@ void MixerMotor:: StopMotor(){
   digitalWrite(MP2,LOW);
 }
  
-void MixerMotor:: SetSpeed(int PWM) {
+void MixerMotor:: SetSpeed(int PWM, int mixerDir) {
   analogWrite(E,PWM);
   delay(500);
-  digitalWrite(MP1,HIGH); //one way
-  digitalWrite(MP2,LOW);
-  // delay(500);
-  // analogWrite(E,PWM);
+  if(mixerDir == 0)
+  {
+    digitalWrite(MP1,HIGH); //one way
+    digitalWrite(MP2,LOW);
+  }
+  else if (mixerDir == 1)
+  {
+    digitalWrite(MP1,LOW); //one way
+    digitalWrite(MP2,HIGH);
+  }
 }

--- a/Modules/1006 SHUT/ARCaDIUS_SHUT/MixerMotor.h
+++ b/Modules/1006 SHUT/ARCaDIUS_SHUT/MixerMotor.h
@@ -18,7 +18,7 @@ class MixerMotor
 
   void StopMotor();
 
-  void SetSpeed(int PWM);
+  void SetSpeed(int PWM, int mixerDir);
 
 };
 #endif

--- a/Modules/1006 SHUT/ARCaDIUS_SHUT/Shutter.cpp
+++ b/Modules/1006 SHUT/ARCaDIUS_SHUT/Shutter.cpp
@@ -5,54 +5,54 @@
 
 
 
-    Shutter::Shutter(int inputpin, int outputpin) :input_pin(inputpin), output_pin(outputpin) {};
+Shutter::Shutter(int inputpin, int outputpin) :input_pin(inputpin), output_pin(outputpin) {};
 
-    void Shutter::Initialise() {
-        ShutterServo.attach(output_pin);
-        ShutterServo.write(90);
-        }
+void Shutter::Initialise() {
+    ShutterServo.attach(output_pin);
+    ShutterServo.write(90);
+    }
 
-    void Shutter::goto_open (double desired){
-        Serial.println("goto_open");
-        double Input = desired+26;
-        //Serial.println((unsigned int)((0.728*Input)-19.105));
-        ShutterServo.write((unsigned int)((0.728*Input)-19.105));
-        delay(500);
+void Shutter::goto_open (double desired){
+    Serial.println("goto_open");
+    double Input = desired+26;
+    //Serial.println((unsigned int)((0.728*Input)-19.105));
+    ShutterServo.write((unsigned int)((0.728*Input)-19.105));
+    delay(500);
+};
+
+double Shutter::get(void){
+    double in = 0;
+    for(int i=0; i<10; i++){
+        in += analogRead(input_pin);
+        delay(5);
+    }
+    double Average = in/10;
+return ((0.4826*Average-26));
+};
+
+void Shutter::goto_controlled (double desired){
+    uint16_t pos = ShutterServo.read();
+    double diff=((desired)-(this->get()));
+    //Serial.println(diff);
+    double Ki = 0;
+    while ((abs(diff))>3){
+        // Serial.println(diff);
+        double changepos= 0.3*diff;  //Kp
+        // Ki += 0.0004*diff;            //Ki
+        pos += (int) (changepos + Ki);
+        if (pos>180) pos = 180;
+        if (pos<0) pos =0;
+        ShutterServo.write(pos);
+        delay(150);
+        diff=((desired)-(this->get()));
+        Serial.println(diff);
+    }
+};
+
+void Shutter::moveto(state pos, bool controller){
+    if(controller) {
+        this->goto_controlled(pos);
+    }else{
+        this->goto_open(pos); 
     };
-
-    double Shutter::get(void){
-        double in = 0;
-        for(int i=0; i<10; i++){
-            in += analogRead(input_pin);
-            delay(5);
-        }
-        double Average = in/10;
-    return ((0.4826*Average-26));
-    };
-
-    void Shutter::goto_controlled (double desired){
-        uint16_t pos = ShutterServo.read();
-        double diff=((desired)-(this->get()));
-        //Serial.println(diff);
-        double Ki = 0;
-        while ((abs(diff))>3){
-            // Serial.println(diff);
-            double changepos= 0.3*diff;  //Kp
-            // Ki += 0.0004*diff;            //Ki
-            pos += (int) (changepos + Ki);
-            if (pos>180) pos = 180;
-            if (pos<0) pos =0;
-            ShutterServo.write(pos);
-            delay(150);
-            diff=((desired)-(this->get()));
-            Serial.println(diff);
-        }
-    };
-
-    void Shutter::moveto(state pos, bool controller){
-        if(controller) {
-            this->goto_controlled(pos);
-        }else{
-            this->goto_open(pos); 
-        };
-    };
+};

--- a/Modules/1007 EXT/ARCaDIUS_EXT/ARCaDIUS_Serial.cpp
+++ b/Modules/1007 EXT/ARCaDIUS_EXT/ARCaDIUS_Serial.cpp
@@ -277,7 +277,6 @@ void ASerial::Shutter() {
 void ASerial::Extract()
 {
   String rubbish;
-  extract = Command[1] - '0';
   rubbish = readStringuntil(Command, 'S');
   Command.remove(0, rubbish.length());
   extractPos = readStringuntil(Command,' ').toInt();
@@ -395,11 +394,6 @@ int ASerial::GetCommand() {
     return op;
   }
   return -1;
-}
-
-int ASerial::getExtractPos()
-{
-  return extractPos;
 }
 
 void ASerial::FinishedCommand() {

--- a/Modules/readme.md
+++ b/Modules/readme.md
@@ -1,9 +1,9 @@
 List of commands:
-[sID1000 rID PK1 V Sy] : Valve command,  Opens valve y, closes valves less than y, sets valves greater than y to middle position. ex. S2 = valve 2 opens, valve 1 closes, valve 3-5 middle.
-[sID1000 rID PK1 U Sx] : Where x is a 5 long digit string consisting of only digits 0-2, sets valve position according to the digit in the string. ex. 01200 - valve 1 = open, valve 2 = closed, valve 3 = middle, valve 4 = open, valve 5 = open.
-[sID1000 rID PK1 E Sx] : Servo command, rotates servo motor to x degrees (absolute, not relative). ex. S20 = 20 degrees rotation from 0.
-[sID1000 rID PK1 P mx] : Peristaltic pump command, pumps x mls. ex. m2 pumps 2 mls.
-[sID1000 rID PK1 Y Sx] : Syringe pump command, pumps x mls. ex. m2 pumps 2 mls.
-[sID1000 rID PK2 M Sx Dy] : Mixer module command, x PWM, spins in y direction (1 = clockwise, 0 = anti-clockwise). ex. S80 D1 spins at 80 pwm clockwise.
-[sID1000 rID PK1 I Sx] : Shutter command, Rotates shutter according to S parameter (x = 0: closed, x = 1: open, x = 2: middle). ex. S1 opens the shutter.
-[sID1000 rID PK0 R] : Read command, reads sensors present on the module. Prints the following on the serial line: (sID rID1000 PKx SEN y Sz) where x is the packet size for a certain amount of sensors, y is the sensor type (T = Temperature, B = Bubble, S = LDS) and number, and z is value read from the sensor.
+[sID1000 rID PK2 V Sy] : Valve command,  Opens valve y, closes valves less than y, sets valves greater than y to middle position. ex. S2 = valve 2 opens, valve 1 closes, valve 3-5 middle.
+[sID1000 rID PK2 U Sx] : Where x is a 5 long digit string consisting of only digits 0-2, sets valve position according to the digit in the string. ex. 01200 - valve 1 = open, valve 2 = closed, valve 3 = middle, valve 4 = open, valve 5 = open.
+[sID1000 rID PK2 E Sx] : Servo command, rotates servo motor to x degrees (absolute, not relative). ex. S20 = 20 degrees rotation from 0.
+[sID1000 rID PK2 P mx] : Peristaltic pump command, pumps x mls. ex. m2 pumps 2 mls.
+[sID1000 rID PK2 Y Sx] : Syringe pump command, pumps x mls. ex. m2 pumps 2 mls.
+[sID1000 rID PK3 M Sx Dy] : Mixer module command, x PWM, spins in y direction (1 = clockwise, 0 = anti-clockwise). ex. S80 D1 spins at 80 pwm clockwise.
+[sID1000 rID PK2 I Sx] : Shutter command, Rotates shutter according to S parameter (x = 0: closed, x = 1: open, x = 2: middle). ex. S1 opens the shutter.
+[sID1000 rID PK1 R] : Read command, reads sensors present on the module. Prints the following on the serial line: (sID rID1000 PKx SEN y Sz) where x is the packet size for a certain amount of sensors, y is the sensor type (T = Temperature, B = Bubble, S = LDS) and number, and z is value read from the sensor.

--- a/Modules/readme.md
+++ b/Modules/readme.md
@@ -1,0 +1,9 @@
+List of commands:
+[sID1000 rID PK1 V Sy] : Valve command,  Opens valve y, closes valves less than y, sets valves greater than y to middle position. ex. S2 = valve 2 opens, valve 1 closes, valve 3-5 middle.
+[sID1000 rID PK1 U Sx] : Where x is a 5 long digit string consisting of only digits 0-2, sets valve position according to the digit in the string. ex. 01200 - valve 1 = open, valve 2 = closed, valve 3 = middle, valve 4 = open, valve 5 = open.
+[sID1000 rID PK1 E Sx] : Servo command, rotates servo motor to x degrees (absolute, not relative). ex. S20 = 20 degrees rotation from 0.
+[sID1000 rID PK1 P mx] : Peristaltic pump command, pumps x mls. ex. m2 pumps 2 mls.
+[sID1000 rID PK1 Y Sx] : Syringe pump command, pumps x mls. ex. m2 pumps 2 mls.
+[sID1000 rID PK2 M Sx Dy] : Mixer module command, x PWM, spins in y direction (1 = clockwise, 0 = anti-clockwise). ex. S80 D1 spins at 80 pwm clockwise.
+[sID1000 rID PK1 I Sx] : Shutter command, Rotates shutter according to S parameter (x = 0: closed, x = 1: open, x = 2: middle). ex. S1 opens the shutter.
+[sID1000 rID PK0 R] : Read command, reads sensors present on the module. Prints the following on the serial line: (sID rID1000 PKx SEN y Sz) where x is the packet size for a certain amount of sensors, y is the sensor type (T = Temperature, B = Bubble, S = LDS) and number, and z is value read from the sensor.


### PR DESCRIPTION
Moved valve handling from software to firmware. Confirmed to work on hardware.
Maybe this should be tested on the software as well before merging?

There are now two modes to valve handling:
[sID1000 rID100x PK1 Vy] : Opens valve y, closes valves less than y, sets valves greater than y to middle position.
[sID1000 rID100x PK1 Uy] : Where y is a 5 long digit string consisting of only digits 0-2, sets valve position according to the digit in the string. ex. 01200 - valve 1 = open, valve 2 = closed, valve 3 = middle, valve 4 = open, valve 5 = open.

When flagging an error in OpenMultipleValves(), the operation still goes through, it simply flags that one of the valves has an invalid position. This should be fine (theoretically).